### PR TITLE
Add when_matched support to non-idempotent time-range materialization

### DIFF
--- a/sqlmesh_utils/materializations/non_idempotent_incremental_by_time_range.py
+++ b/sqlmesh_utils/materializations/non_idempotent_incremental_by_time_range.py
@@ -3,11 +3,16 @@ import typing as t
 from sqlmesh import CustomMaterialization
 from sqlmesh.core.model import Model
 from sqlmesh.core.model.kind import TimeColumn
+import sqlmesh.core.dialect as d
 from sqlglot import exp
 from sqlmesh.utils.date import make_inclusive
 from sqlmesh.utils.errors import ConfigError, SQLMeshError
 from pydantic import model_validator
-from sqlmesh.utils.pydantic import list_of_fields_validator, bool_validator
+from sqlmesh.utils.pydantic import (
+    bool_validator,
+    list_of_fields_validator,
+    validate_expression,
+)
 from sqlmesh.utils.date import TimeLike
 from sqlmesh.core.engine_adapter.base import MERGE_SOURCE_ALIAS, MERGE_TARGET_ALIAS
 from sqlmesh import CustomKind
@@ -22,6 +27,26 @@ class NonIdempotentIncrementalByTimeRangeKind(CustomKind):
     _primary_key: t.List[exp.Expression]
 
     _partition_by_time_column: bool
+    _when_matched: t.Optional[exp.Whens]
+
+    def _parse_when_matched(self, value: t.Any) -> t.Optional[exp.Whens]:
+        if value is None:
+            return None
+
+        if isinstance(value, list):
+            value = " ".join(value)
+
+        if isinstance(value, str):
+            value = value.strip()
+            if value.startswith("("):
+                value = value[1:-1]
+            value = t.cast(exp.Whens, d.parse_one(value, into=exp.Whens, dialect=self.dialect))
+
+        value = validate_expression(value, dialect=self.dialect)
+        return t.cast(
+            exp.Whens,
+            value.transform(d.replace_merge_table_aliases, dialect=self.dialect),
+        )
 
     @model_validator(mode="after")
     def _validate_model(self):
@@ -49,6 +74,10 @@ class NonIdempotentIncrementalByTimeRangeKind(CustomKind):
             self.materialization_properties.get("partition_by_time_column", True)
         )
 
+        self._when_matched = self._parse_when_matched(
+            self.materialization_properties.get("when_matched")
+        )
+
         return self
 
     @property
@@ -62,6 +91,10 @@ class NonIdempotentIncrementalByTimeRangeKind(CustomKind):
     @property
     def partition_by_time_column(self) -> bool:
         return self._partition_by_time_column
+
+    @property
+    def when_matched(self) -> t.Optional[exp.Whens]:
+        return self._when_matched
 
 
 class NonIdempotentIncrementalByTimeRangeMaterialization(
@@ -130,6 +163,7 @@ class NonIdempotentIncrementalByTimeRangeMaterialization(
             source_table=query_or_df,
             target_columns_to_types=columns_to_types,
             unique_key=model.kind.primary_key,
+            when_matched=model.kind.when_matched,
             merge_filter=exp.and_(*betweens),
             source_columns=source_columns,
         )

--- a/tests/materializations/test_non_idempotent_incremental_by_time_range.py
+++ b/tests/materializations/test_non_idempotent_incremental_by_time_range.py
@@ -59,6 +59,7 @@ def test_kind(make_model: ModelMaker):
         exp.to_column("id", quoted=True),
         exp.to_column("ds", quoted=True),
     ]
+    assert isinstance(model.kind, NonIdempotentIncrementalByTimeRangeKind)
     assert model.kind.when_matched is None
 
     model = make_model(
@@ -68,6 +69,7 @@ def test_kind(make_model: ModelMaker):
             "when_matched = 'when matched then update set target.name = source.name'",
         ]
     )
+    assert isinstance(model.kind, NonIdempotentIncrementalByTimeRangeKind)
     assert model.kind.when_matched is not None
 
     # required fields
@@ -237,8 +239,45 @@ def test_when_matched_multiple_clauses(make_model: ModelMaker):
             "when_matched = 'when matched and source.name is null then delete when matched then update set target.name = source.name'",
         ]
     )
+    assert isinstance(model.kind, NonIdempotentIncrementalByTimeRangeKind)
     assert model.kind.when_matched is not None
     assert len(model.kind.when_matched.expressions) == 2
+
+
+def test_when_matched_as_list(make_model: ModelMaker):
+    model = make_model(
+        [
+            "time_column = ds",
+            "primary_key = (id, ds)",
+            "when_matched = ['when matched then', 'update set target.name = source.name']",
+        ]
+    )
+    assert isinstance(model.kind, NonIdempotentIncrementalByTimeRangeKind)
+    assert model.kind.when_matched is not None
+
+
+def test_when_matched_with_parens(make_model: ModelMaker):
+    model = make_model(
+        [
+            "time_column = ds",
+            "primary_key = (id, ds)",
+            "when_matched = '(when matched then update set target.name = source.name)'",
+        ]
+    )
+    assert isinstance(model.kind, NonIdempotentIncrementalByTimeRangeKind)
+    assert model.kind.when_matched is not None
+
+
+def test_when_matched_with_whitespace(make_model: ModelMaker):
+    model = make_model(
+        [
+            "time_column = ds",
+            "primary_key = (id, ds)",
+            "when_matched = '  when matched then update set target.name = source.name  '",
+        ]
+    )
+    assert isinstance(model.kind, NonIdempotentIncrementalByTimeRangeKind)
+    assert model.kind.when_matched is not None
 
 
 def test_when_matched_invalid_syntax(make_model: ModelMaker):

--- a/tests/materializations/test_non_idempotent_incremental_by_time_range.py
+++ b/tests/materializations/test_non_idempotent_incremental_by_time_range.py
@@ -59,6 +59,16 @@ def test_kind(make_model: ModelMaker):
         exp.to_column("id", quoted=True),
         exp.to_column("ds", quoted=True),
     ]
+    assert model.kind.when_matched is None
+
+    model = make_model(
+        [
+            "time_column = ds",
+            "primary_key = (id, ds)",
+            "when_matched = 'when matched then update set target.name = source.name'",
+        ]
+    )
+    assert model.kind.when_matched is not None
 
     # required fields
     with pytest.raises(ConfigError, match=r"Invalid time_column"):
@@ -163,6 +173,83 @@ def test_append(make_model: ModelMaker, make_mocked_engine_adapter: MockedEngine
             dialect=adapter.dialect,
         ).sql(dialect=adapter.dialect),
     ]
+
+
+def test_insert_with_when_matched(
+    make_model: ModelMaker, make_mocked_engine_adapter: MockedEngineAdapterMaker
+):
+    model: Model = make_model(
+        [
+            "time_column = ds",
+            "primary_key = name",
+            "when_matched = 'when matched then update set target.name = source.name'",
+        ],
+        dialect="trino",
+    )
+    adapter = make_mocked_engine_adapter(TrinoEngineAdapter)
+    strategy = NonIdempotentIncrementalByTimeRangeMaterialization(adapter)
+
+    start = to_timestamp("2020-01-01")
+    end = to_timestamp("2020-01-03")
+
+    strategy.insert(
+        "test.snapshot_table",
+        query_or_df=model.render_query(
+            start=start, end=end, execution_time=now(), runtime_stage=RuntimeStage.EVALUATING
+        ),
+        model=model,
+        is_first_insert=False,
+        start=start,
+        end=end,
+        render_kwargs={},
+    )
+
+    assert to_sql_calls(adapter) == [
+        parse_one(
+            """
+            MERGE INTO "test"."snapshot_table" AS "__merge_target__"
+            USING (
+            SELECT
+                CAST("name" AS VARCHAR) AS "name",
+                CAST("ds" AS TIMESTAMP) AS "ds"
+            FROM "upstream"."table" AS "table"
+            WHERE
+                "ds" BETWEEN '2020-01-01 00:00:00' AND '2020-01-02 23:59:59.999999'
+            ) AS "__MERGE_SOURCE__"
+            ON (
+                "__MERGE_SOURCE__"."ds" BETWEEN CAST('2020-01-01 00:00:00' AS TIMESTAMP) AND CAST('2020-01-02 23:59:59.999999' AS TIMESTAMP)
+                AND "__MERGE_TARGET__"."ds" BETWEEN CAST('2020-01-01 00:00:00' AS TIMESTAMP) AND CAST('2020-01-02 23:59:59.999999' AS TIMESTAMP)
+            )
+            AND "__MERGE_TARGET__"."name" = "__MERGE_SOURCE__"."name"
+            WHEN MATCHED THEN UPDATE SET "__MERGE_TARGET__"."name" = "__MERGE_SOURCE__"."name"
+            WHEN NOT MATCHED THEN INSERT ("name", "ds") VALUES ("__MERGE_SOURCE__"."name", "__MERGE_SOURCE__"."ds")
+        """,
+            dialect=adapter.dialect,
+        ).sql(dialect=adapter.dialect),
+    ]
+
+
+def test_when_matched_multiple_clauses(make_model: ModelMaker):
+    model = make_model(
+        [
+            "time_column = ds",
+            "primary_key = (id, ds)",
+            "when_matched = 'when matched and source.name is null then delete when matched then update set target.name = source.name'",
+        ]
+    )
+    assert model.kind.when_matched is not None
+    assert len(model.kind.when_matched.expressions) == 2
+
+
+def test_when_matched_invalid_syntax(make_model: ModelMaker):
+    with pytest.raises(Exception):
+        make_model(
+            [
+                "time_column = ds",
+                "primary_key = (id, ds)",
+                "when_matched = 'this is not valid sql'",
+            ]
+        )
 
 
 def test_partition_by_time_column_opt_out(make_model: ModelMaker):


### PR DESCRIPTION
## Summary
- Add optional `materialization_properties.when_matched` support to `non_idempotent_incremental_by_time_range`.
- Parse and normalize `when_matched` using SQLMesh's expression validation and merge-alias replacement semantics, then pass it through to `adapter.merge(...)`.
- Add unit coverage to verify custom `WHEN MATCHED` clauses are respected in generated MERGE SQL.

## Why
`non_idempotent_incremental_by_time_range` currently always updates all columns on key match. This makes it impossible to keep immutable ingestion metadata such as `_inserted_at` unchanged on updates. Supporting `when_matched` gives model authors explicit control over update behavior while preserving existing defaults when unset.

## Implementation Notes
This follows SQLMesh's existing `INCREMENTAL_BY_UNIQUE_KEY` flow:
- `IncrementalByUniqueKeyKind.when_matched` parsing/validation:
  - https://github.com/TobikoData/sqlmesh/blob/main/sqlmesh/core/model/kind.py#L510-L560
- Passing `when_matched` into merge in strategy:
  - https://github.com/TobikoData/sqlmesh/blob/main/sqlmesh/core/snapshot/evaluator.py#L2297-L2330
- Engine adapter merge default-vs-custom `when_matched` handling:
  - https://github.com/TobikoData/sqlmesh/blob/main/sqlmesh/core/engine_adapter/base.py#L2205-L2273

## Validation
- `uv run pytest tests/materializations/test_non_idempotent_incremental_by_time_range.py -q`